### PR TITLE
Add a build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0      
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
       - name: Install dependencies
         run: npm ci
@@ -41,12 +48,20 @@ jobs:
       - name: Test if the executable is available
         run: v version
 
-      - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        id: create_release
-        uses: ncipollo/release-action@v1
-        with:
-          name: setup-v
-          generateReleaseNotes: true
-          body: ${{steps.build_changelog.outputs.changelog}}
-          token: ${{ secrets.GITHUB_TOKEN }}
+  publish:
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  
+
+    - name: Create Release
+      if: startsWith(github.ref, 'refs/tags/v')
+      id: create_release
+      uses: ncipollo/release-action@v1
+      with:
+        name: setup-v
+        generateReleaseNotes: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,8 @@
-trailingComma: "es5"
-tabWidth: 2
-semi: false
-singleQuote: true
-bracketSpacing: true
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true,
+    "bracketSpacing": true,
+    "endOfLine": "auto"
+}

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -90,9 +90,10 @@ describe('installer', () => {
       stdout: '',
       stderr: 'oh noes',
     }
+    const pathToBin = path.join('fake_path', 'v')
     execSpy.mockImplementation(() => Promise.resolve(o))
     await expect(i.getVersion('fake_path')).rejects.toThrow(
-      Error('Unable to get version from fake_path/v')
+      Error(`Unable to get version from ${pathToBin}`)
     )
   })
 


### PR DESCRIPTION
We need to ensure that the action runs on multiple operating systems. This PR adds a build matrix and also moves publish in to a new job.