### PR TITLE
Normalize platform rather than whole filename

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -54,27 +54,21 @@ describe('installer', () => {
     console.log('::stoptoken::') // Re-enable executing of runner commands when running tests in actions
   }, 100000)
 
-  test('getArchiveForPlatform returns correct extension for win32', () => {
+  test('normalizePlatform returns correct result for win32', () => {
     os['platform'] = 'win32'
-    expect(i.getArchiveForPlatform()).toBe('v_windows.zip')
+    expect(i.normalizePlatform()).toBe('windows')
   })
 
-  test('getArchiveForPlatform returns correct extension for darwin', () => {
+  test('normalizePlatform returns correct result for darwin', () => {
     os['platform'] = 'darwin'
-    expect(i.getArchiveForPlatform()).toBe('v_macos.zip')
+    expect(i.normalizePlatform()).toBe('macos')
   })
 
-  test('getArchiveForPlatform returns correct extension for linux', () => {
+  test('normalizePlatform returns correct result for linux', () => {
     os['platform'] = 'linux'
-    expect(i.getArchiveForPlatform()).toBe('v_linux.zip')
+    expect(i.normalizePlatform()).toBe('linux')
   })
 
-  test('getArchiveForPlatform handles unknown platform', () => {
-    os['platform'] = 'fake'
-    expect(() => {
-      i.getArchiveForPlatform()
-    }).toThrow('Unsupported platform: fake')
-  })
 
   test('getVersion returns correct version string', async () => {
     const o = {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -20,7 +20,8 @@ export async function setup(): Promise<void> {
     requestedVersion = await resolveLatestRelease(token)
   }
 
-  const archive = getArchiveForPlatform()
+  const platform = normalizePlatform()
+  const archive = `v_${platform}.zip`
   const url = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/${requestedVersion}/${archive}`
 
   try {
@@ -56,17 +57,14 @@ export async function resolveLatestRelease(token: string): Promise<string> {
   return release.data.tag_name
 }
 
-export function getArchiveForPlatform(): string {
-  switch (os.platform()) {
-    case 'darwin':
-      return 'v_macos.zip'
-    case 'win32':
-      return 'v_windows.zip'
-    case 'linux':
-      return 'v_linux.zip'
-    default:
-      throw new Error(`Unsupported platform: ${os.platform()}`)
+export function normalizePlatform(): string {
+  const platform = os.platform()
+  const platformMap: Record<string, string> = {
+    darwin: 'macos',
+    win32: 'windows',
   }
+
+  return platformMap[platform.toString()] || platform
 }
 
 export async function getVersion(binPath: string): Promise<string> {


### PR DESCRIPTION
It felt weird creating the whole filename from the platform. This PR changes the behaviour so we are only normalizing the platform name, then building the filename
later.